### PR TITLE
Update d-tracker.desktop icon

### DIFF
--- a/platform/linux/d-tracker.desktop
+++ b/platform/linux/d-tracker.desktop
@@ -5,5 +5,5 @@ Terminal=false
 GenericName=A lightweight timetracker that looks like hamster
 Categories=Utility;
 Exec=d-tracker
-Icon=d-tracker.png
+Icon=d-tracker
 StartupWMClass=d-tracker


### PR DESCRIPTION
There is no icon displayed with [rofi](https://github.com/davatorium/rofi), removing the file extension seems to fix that

I've tested that on gnome-shell as well and it looks fine (I've no experience in *.desktop files though)

Can you confirm if it's ok on your linux setup?